### PR TITLE
Die nicely if input reads bad, or when no contigs made

### DIFF
--- a/scripts/iva
+++ b/scripts/iva
@@ -158,6 +158,10 @@ else:
     if options.threads > 1:
         p1.join()
 
+    if p1.exitcode != 0 or p2.exitcode != 0:
+        print('Error in input reads files. Cannot continue', file=sys.stderr)
+        sys.exit(1)
+
     for fname in to_delete:
         os.unlink(fname)
 

--- a/scripts/iva
+++ b/scripts/iva
@@ -57,11 +57,11 @@ trimming_group.add_argument('--trimmomatic', action=iva.common.abspathAction, he
 trimming_group.add_argument('--trimmo_qual', help='Trimmomatic options used to quality trim reads [%(default)s]', default='LEADING:10 TRAILING:10 SLIDINGWINDOW:4:20', metavar='STRING')
 trimming_group.add_argument('--adapters', action=iva.common.abspathAction, help='Fasta file of adapter sequences to be trimmed off reads. If used, must also use --trimmomatic. Default is file of adapters supplied with IVA', metavar='FILENAME')
 trimming_group.add_argument('--min_trimmed_length', type=int, help='Minimum length of read after trimming [%(default)s]', default=50, metavar='INT')
-trimming_group.add_argument('--pcr_primers', action=iva.common.abspathAction, help='FASTA file of primers. The first perfect match found to a sequence in the primers file will be trimmed off the start of each read. This is run after trimmomatic (if --trimmomatic used)', metavar='FILENAME') 
+trimming_group.add_argument('--pcr_primers', action=iva.common.abspathAction, help='FASTA file of primers. The first perfect match found to a sequence in the primers file will be trimmed off the start of each read. This is run after trimmomatic (if --trimmomatic used)', metavar='FILENAME')
 
 
 other_group = parser.add_argument_group('Other options')
-other_group.add_argument('-i', '--max_insert', type=int, help='Maximum insert size (includes read length). Reads with inferred insert size more than the maximum will not be used to extend contigs [%(default)s]', default=500, metavar='INT')
+other_group.add_argument('-i', '--max_insert', type=int, help='Maximum insert size (includes read length). Reads with inferred insert size more than the maximum will not be used to extend contigs [%(default)s]', default=800, metavar='INT')
 other_group.add_argument('-t', '--threads', type=int, help='Number of threads to use [%(default)s]', default=1, metavar='INT')
 other_group.add_argument('--strand_bias', type=float, help='Set strand bias cutoff of mapped reads when trimming contig ends, in the interval [0,0.5]. A value of x means that a base needs min(fwd_depth, rev_depth) / total_depth <= x. [%(default)s]', default=0.1, metavar='FLOAT in [0,0.5]')
 other_group.add_argument('--version', action='version', version=iva.common.version)


### PR DESCRIPTION
Fixes two bugs:
1. Errors were not caught when converting reads to fasta, so would continue trying to assemble if input files were invalid and bad things happen. Now it dies gracefully
2. Sometimes no contigs get made and IVA would die horribly. This is now handled properly with useful output for the user.