### PR TITLE
Use pyfastaq 3.10.0

### DIFF
--- a/iva/common.py
+++ b/iva/common.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import sys
 import subprocess
-version = '1.0.0'
+version = '1.0.1'
 
 class abspathAction(argparse.Action):
     def __call__(self, parser, namespace, value, option_string):

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if not found_all_progs:
 
 setup(
     name='iva',
-    version='1.0.0',
+    version='1.0.1',
     description='Iterative Virus Assembler',
     packages = find_packages(),
     package_data={'iva': ['gage/*', 'ratt/*', 'read_trim/*']},

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     test_suite='nose.collector',
     tests_require=['nose >= 1.3'],
     install_requires=[
-        'pyfastaq >= 3.0.1',
+        'pyfastaq >= 3.10.0',
         'networkx >= 1.7',
         'pysam >= 0.8.1'
     ],


### PR DESCRIPTION
This just changes the required version of pyfastaq to >=3.10.0, which removes the dependency on numpy. Should fix some installation issues.