### PR TITLE
Kmc threads

### DIFF
--- a/iva/assembly.py
+++ b/iva/assembly.py
@@ -6,12 +6,13 @@ from iva import contig, mapping, seed, mummer, graph, edge, common
 import pyfastaq
 
 class Assembly:
-    def __init__(self, contigs_file=None, map_index_k=15, map_index_s=3, threads=1, max_insert=800, map_minid=0.5, min_clip=3, ext_min_cov=5, ext_min_ratio=2, ext_bases=100, verbose=0, seed_min_cov=5, seed_min_ratio=10, seed_min_kmer_count=200, seed_max_kmer_count=1000000000, seed_start_length=None, seed_stop_length=500, seed_overlap_length=None, make_new_seeds=False, contig_iter_trim=10, seed_ext_max_bases=50, max_contigs=50, clean=True, strand_bias=0):
+    def __init__(self, contigs_file=None, map_index_k=15, map_index_s=3, threads=1, kmc_threads=1, max_insert=800, map_minid=0.5, min_clip=3, ext_min_cov=5, ext_min_ratio=2, ext_bases=100, verbose=0, seed_min_cov=5, seed_min_ratio=10, seed_min_kmer_count=200, seed_max_kmer_count=1000000000, seed_start_length=None, seed_stop_length=500, seed_overlap_length=None, make_new_seeds=False, contig_iter_trim=10, seed_ext_max_bases=50, max_contigs=50, clean=True, strand_bias=0):
         self.contigs = {}
         self.contig_lengths = {}
         self.map_index_k = map_index_k
         self.map_index_s = map_index_s
         self.threads = threads
+        self.kmc_threads = kmc_threads
         self.max_insert = max_insert
         self.map_minid = map_minid
         self.min_clip = min_clip
@@ -583,7 +584,7 @@ class Assembly:
         made_seed = False
 
         for i in range(max_attempts):
-            s = seed.Seed(reads1=seed_reads1, reads2=seed_reads2, extend_length=self.seed_ext_max_bases, seed_length=self.seed_start_length, seed_min_count=self.seed_min_kmer_count, seed_max_count=self.seed_max_kmer_count, ext_min_cov=self.seed_min_cov, ext_min_ratio=self.seed_min_ratio, verbose=self.verbose, threads=self.threads, sequences_to_ignore=self.used_seeds, contigs_to_check=self.contigs)
+            s = seed.Seed(reads1=seed_reads1, reads2=seed_reads2, extend_length=self.seed_ext_max_bases, seed_length=self.seed_start_length, seed_min_count=self.seed_min_kmer_count, seed_max_count=self.seed_max_kmer_count, ext_min_cov=self.seed_min_cov, ext_min_ratio=self.seed_min_ratio, verbose=self.verbose, kmc_threads=self.kmc_threads, map_threads=self.threads, sequences_to_ignore=self.used_seeds, contigs_to_check=self.contigs)
 
             if s.seq is None or len(s.seq) == 0:
                 break

--- a/iva/common.py
+++ b/iva/common.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import sys
 import subprocess
-version = '1.0.2'
+version = '1.0.3'
 
 class abspathAction(argparse.Action):
     def __call__(self, parser, namespace, value, option_string):

--- a/iva/seed.py
+++ b/iva/seed.py
@@ -8,13 +8,14 @@ from iva import kcount, kmers, mapping
 class Error (Exception): pass
 
 class Seed:
-    def __init__(self, extend_length=50, overlap_length=None, reads1=None, reads2=None, seq=None, ext_min_cov=5, ext_min_ratio=2, verbose=0, seed_length=None, seed_min_count=10, seed_max_count=100000000, threads=1, sequences_to_ignore=None, contigs_to_check=None):
+    def __init__(self, extend_length=50, overlap_length=None, reads1=None, reads2=None, seq=None, ext_min_cov=5, ext_min_ratio=2, verbose=0, seed_length=None, seed_min_count=10, seed_max_count=100000000, kmc_threads=1, map_threads=1, sequences_to_ignore=None, contigs_to_check=None):
         if contigs_to_check is None:
             contigs_to_check = {}
         if sequences_to_ignore is None:
             sequences_to_ignore = set()
         self.verbose = verbose
-        self.threads = threads
+        self.kmc_threads = kmc_threads
+        self.map_threads = map_threads
         self.extend_length = extend_length
         self.ext_min_cov = ext_min_cov
         self.ext_min_ratio = ext_min_ratio
@@ -23,7 +24,7 @@ class Seed:
         if seq is None:
             if reads1 is None:
                 raise Error('Cannot construct Seed object. Need reads when no seq has been given')
-            kmer_counts = kcount.get_most_common_kmers(reads1, reads2, most_common=1, min_count=seed_min_count, max_count=seed_max_count, kmer_length=seed_length, verbose=self.verbose, ignore_seqs=sequences_to_ignore, contigs_to_check=contigs_to_check)
+            kmer_counts = kcount.get_most_common_kmers(reads1, reads2, most_common=1, min_count=seed_min_count, max_count=seed_max_count, kmer_length=seed_length, verbose=self.verbose, ignore_seqs=sequences_to_ignore, contigs_to_check=contigs_to_check, kmc_threads=self.kmc_threads, map_threads=self.map_threads)
             if len(kmer_counts) == 1:
                 self.seq = list(kmer_counts.keys())[0]
                 if self.verbose:

--- a/iva/seed_processor.py
+++ b/iva/seed_processor.py
@@ -9,7 +9,7 @@ import pyfastaq
 class Error (Exception): pass
 
 class SeedProcessor:
-    def __init__(self, seeds_fasta, reads1, reads2, outfile, index_k=15, index_s=3, threads=1, max_insert=500, minid=0.9, seed_stop_length=500, extend_length=50, overlap_length=None, ext_min_cov=5, ext_min_ratio=2, verbose=0, seed_length=None, seed_min_count=10, seed_max_count=100000000):
+    def __init__(self, seeds_fasta, reads1, reads2, outfile, index_k=15, index_s=3, threads=1, max_insert=500, minid=0.9, seed_stop_length=500, extend_length=50, overlap_length=None, ext_min_cov=5, ext_min_ratio=2, verbose=0, seed_length=None, seed_min_count=10, seed_max_count=100000000, kmc_threads=1):
         self.seeds_fasta = seeds_fasta
         self.reads1 = reads1
         self.reads2 = reads2
@@ -17,6 +17,7 @@ class SeedProcessor:
         self.index_k = index_k
         self.index_s = index_s
         self.threads = threads
+        self.kmc_threads = kmc_threads
         self.max_insert = max_insert
         self.minid = minid
         self.seed_stop_length = seed_stop_length
@@ -61,7 +62,9 @@ class SeedProcessor:
             verbose = self.verbose,
             seed_length = self.seed_length,
             seed_min_count = self.seed_min_count,
-            seed_max_count = self.seed_max_count
+            seed_max_count = self.seed_max_count,
+            kmc_threads = self.kmc_threads,
+            map_threads = self.threads
         )
         if len(new_seed) == 0:
             print('Warning: could not get most common kmer for', seed_name)

--- a/iva/tests/kcount_test.py
+++ b/iva/tests/kcount_test.py
@@ -42,6 +42,14 @@ class TestKcount(unittest.TestCase):
         os.unlink(counts_file)
 
 
+    def test_run_kmc_two_threads(self):
+        '''Test test_run_kmc with two threads'''
+        reads = os.path.join(data_dir, 'kcount_test.run_kmc.fa')
+        counts_file = kcount._run_kmc(reads, 'tmp.run_kmc', 10, 2, 4, threads=2)
+        self.assertTrue(filecmp.cmp(counts_file, os.path.join(data_dir, 'kcount_test.run_kmc.counts'), shallow=False))
+        os.unlink(counts_file)
+
+
     def test_kmc_to_kmer_counts(self):
         '''Test _kmc_to_kmer_counts'''
         counts = kcount._kmc_to_kmer_counts(os.path.join(data_dir, 'kcount_test.kmc_counts'), number=2)

--- a/scripts/iva
+++ b/scripts/iva
@@ -63,6 +63,7 @@ trimming_group.add_argument('--pcr_primers', action=iva.common.abspathAction, he
 other_group = parser.add_argument_group('Other options')
 other_group.add_argument('-i', '--max_insert', type=int, help='Maximum insert size (includes read length). Reads with inferred insert size more than the maximum will not be used to extend contigs [%(default)s]', default=800, metavar='INT')
 other_group.add_argument('-t', '--threads', type=int, help='Number of threads to use [%(default)s]', default=1, metavar='INT')
+other_group.add_argument('--kmc_onethread', action='store_true', help='Force kmc to use one thread. By default the value of -t/--threads is used when running kmc')
 other_group.add_argument('--strand_bias', type=float, help='Set strand bias cutoff of mapped reads when trimming contig ends, in the interval [0,0.5]. A value of x means that a base needs min(fwd_depth, rev_depth) / total_depth <= x. The only time this should be used is with libraries with overlapping reads (ie fragment length < 2*read length), and even then, it can make results worse. If used, try a low value like 0.1 first [%(default)s]', default=0, metavar='FLOAT in [0,0.5]')
 other_group.add_argument('--test', action='store_true', help='Run using built in test data. All other options will be ignored, except the mandatory output directory, and --trimmomatic and --threads can be also be used')
 other_group.add_argument('--version', action='version', version=iva.common.version)
@@ -100,6 +101,12 @@ if options.contigs and options.reference:
 if os.path.exists(options.outdir):
     print('Error! Output directory', options.outdir, 'already exists. Cannot continue', file=sys.stderr)
     sys.exit(1)
+
+
+if options.kmc_onethread:
+    kmc_threads = 1
+else:
+    kmc_threads = options.threads
 
 
 iva.external_progs.get_all_versions(iva.external_progs.assembly_progs)
@@ -198,6 +205,7 @@ elif options.reference:
         index_k = options.smalt_k,
         index_s = options.smalt_s,
         threads = options.threads,
+        kmc_threads = kmc_threads,
         max_insert = options.max_insert,
         minid = 0.9,
         seed_stop_length = options.seed_stop_length,
@@ -223,6 +231,7 @@ assembly = iva.assembly.Assembly(
     map_index_k = options.smalt_k,
     map_index_s = options.smalt_s,
     threads = options.threads,
+    kmc_threads = kmc_threads,
     map_minid = options.smalt_id,
     contig_iter_trim = options.ctg_iter_trim,
     ext_min_cov = options.ext_min_cov,

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if not found_all_progs:
 
 setup(
     name='iva',
-    version='1.0.2',
+    version='1.0.3',
     description='Iterative Virus Assembler',
     packages = find_packages(),
     package_data={'iva': ['gage/*', 'ratt/*', 'read_trim/*', 'test_run_data/*']},


### PR DESCRIPTION
This PR changes to run kmc with >1 thread. By default, kmc now uses the same number of threads as everything else. Previously it always used one thread.

 In case this causes issues, also add a user option --kmc_onethread, to force kmc to use one thread.