### PR TITLE
pysam 0.9.0

### DIFF
--- a/iva/common.py
+++ b/iva/common.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import sys
 import subprocess
-version = '1.0.3'
+version = '1.0.4'
 
 class abspathAction(argparse.Action):
     def __call__(self, parser, namespace, value, option_string):

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     install_requires=[
         'pyfastaq >= 3.10.0',
         'networkx >= 1.7',
-        'pysam >= 0.8.1'
+        'pysam >= 0.8.1, <= 0.8.3',
     ],
     license='GPLv3',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if not found_all_progs:
 
 setup(
     name='iva',
-    version='1.0.3',
+    version='1.0.4',
     description='Iterative Virus Assembler',
     packages = find_packages(),
     package_data={'iva': ['gage/*', 'ratt/*', 'read_trim/*', 'test_run_data/*']},


### PR DESCRIPTION
Require pysam 0.8.1-0.8.3 because 0.9.0 won't install.