### PR TITLE
make IVA compatible with new 'samtools sort' syntax

### DIFF
--- a/iva/external_progs.py
+++ b/iva/external_progs.py
@@ -23,10 +23,10 @@ prog_to_version_cmd = {
     'nucmer': ('nucmer --version', re.compile('^NUCmer \(NUCleotide MUMmer\) version (.*)$')),
     'R': ('R --version', re.compile('^R version (.*) \(.*\) --')),
     'smalt': ('smalt version', re.compile('^Version: (.*)$')),
-    'samtools': ('samtools', re.compile('^Version: (.*)$')),
+    'samtools': ('samtools', re.compile('^Version: ([^ ]+)')),
 }
 
- 
+
 minimum_versions = {
     'samtools': '0.1.19'
 }

--- a/iva/mapping.py
+++ b/iva/mapping.py
@@ -5,6 +5,7 @@ import collections
 import pyfastaq
 import pysam
 from iva import common
+from iva import external_progs
 
 class Error (Exception): pass
 
@@ -78,7 +79,10 @@ def map_reads(reads_fwd, reads_rev, ref_fa, out_prefix, index_k=15, index_s=3, t
     if sort:
         threads = min(4, threads)
         thread_mem = int(500 / threads)
-        sort_cmd = 'samtools sort -@' + str(threads) + ' -m ' + str(thread_mem) + 'M ' + intermediate_bam + ' ' + out_prefix
+        if str(external_progs.get_version('samtools')) >= '1.2':
+            sort_cmd = 'samtools sort -@' + str(threads) + ' -m ' + str(thread_mem) + 'M -o ' + final_bam + ' ' + intermediate_bam
+        else:
+            sort_cmd = 'samtools sort -@' + str(threads) + ' -m ' + str(thread_mem) + 'M ' + intermediate_bam + ' ' + out_prefix
         index_cmd = 'samtools index ' + final_bam
         if verbose >= 2:
             print('        map reads. sort:  ', sort_cmd)

--- a/iva/qc_external.py
+++ b/iva/qc_external.py
@@ -142,9 +142,10 @@ def run_ratt(embl_dir, assembly, outdir, config_file=None, transfer='Species', c
     cwd = os.getcwd()
     try:
         os.mkdir(outdir)
-        os.chdir(outdir)
     except:
-        raise Error('Error mkdir ' + outdir)
+        pass
+    os.chdir(outdir)
+    iva.common.syscall('rm -rf ./*')
 
     extractor = iva.egg_extract.Extractor(os.path.abspath(os.path.join(os.path.dirname(iva.__file__), os.pardir)))
     ratt_code_indir = os.path.join('iva', 'ratt')
@@ -200,7 +201,7 @@ def run_ratt(embl_dir, assembly, outdir, config_file=None, transfer='Species', c
             except:
                 pass
 
-        iva.common.syscall('rm query.* Reference.* nucmer.* out.*')
+        iva.common.syscall('rm -f query.* Reference.* nucmer.* out.*')
 
     os.chdir(cwd)
     return stats

--- a/iva/qc_external.py
+++ b/iva/qc_external.py
@@ -140,12 +140,13 @@ def run_ratt(embl_dir, assembly, outdir, config_file=None, transfer='Species', c
     assembly = os.path.abspath(assembly)
 
     cwd = os.getcwd()
-    try:
-        os.mkdir(outdir)
-    except:
-        pass
+    if os.path.exists(outdir):
+        if os.path.isdir(outdir):
+            shutil.rmtree(outdir)
+        else:
+            os.unlink(outdir)
+    os.mkdir(outdir)
     os.chdir(outdir)
-    iva.common.syscall('rm -rf ./*')
 
     extractor = iva.egg_extract.Extractor(os.path.abspath(os.path.join(os.path.dirname(iva.__file__), os.pardir)))
     ratt_code_indir = os.path.join('iva', 'ratt')


### PR DESCRIPTION
This PR adds support for the new `samtools sort` syntax introduced in version 1.2. For older versions, the legacy syntax is automatically used. Tested with samtools versions 1.3.1 and 0.1.20 from Homebrew (just checking if `iva --test` succeeds).
Closes #57.