### PR TITLE
Pysam 0.9.1.x

### DIFF
--- a/iva/common.py
+++ b/iva/common.py
@@ -16,7 +16,7 @@ import argparse
 import os
 import sys
 import subprocess
-version = '1.0.6'
+version = '1.0.7'
 
 class abspathAction(argparse.Action):
     def __call__(self, parser, namespace, value, option_string):

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     install_requires=[
         'pyfastaq >= 3.10.0',
         'networkx >= 1.7',
-        'pysam >= 0.8.1, <= 0.8.3',
+        'pysam >= 0.8.1',
     ],
     license='GPLv3',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ if not found_all_progs:
 
 setup(
     name='iva',
-    version='1.0.6',
+    version='1.0.7',
     description='Iterative Virus Assembler',
     packages = find_packages(),
     package_data={'iva': ['gage/*', 'ratt/*', 'read_trim/*', 'test_run_data/*']},


### PR DESCRIPTION
Drop requirement for pysam <= 0.8.3, as build issues for 0.9.1+ seems to be solved.