### PR TITLE
Set smalt's random seed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@
 FROM debian:testing
 
 # Install required dependancies
-RUN apt-get -qq update && apt-get install -y openjdk-8-jdk python3-pip git wget unzip zlib1g-dev libncurses5-dev
-ENV JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
-RUN git clone https://github.com/sanger-pathogens/iva.git
+RUN apt-get -qq update && apt-get install -y openjdk-13-jdk python3-pip git wget unzip zlib1g-dev libncurses5-dev libbz2-dev liblzma-dev
+ENV JAVA_HOME="/usr/lib/jvm/java-13-openjdk-amd64"
+COPY . iva/
 RUN cd iva && ./install_dependencies.sh
-ENV PATH /iva/build/kmc-2.3.0:/iva/build/samtools-1.3:/iva/build/smalt-0.7.6-bin:/iva/build/samtools-1.3:/iva/build/MUMmer3.23:/iva/build/SPAdes-3.7.1-Linux/bin:$PATH
+ENV PATH /iva/build/kmc-3.0.0:/iva/build/samtools-1.3:/iva/build/smalt-0.7.6-bin:/iva/build/samtools-1.3:/iva/build/MUMmer3.23:/iva/build/SPAdes-3.7.1-Linux/bin:$PATH
 RUN export PATH
 
 # Install optional dependencies

--- a/iva/mapping.py
+++ b/iva/mapping.py
@@ -44,7 +44,7 @@ def map_reads(reads_fwd, reads_rev, ref_fa, out_prefix, index_k=15, index_s=3, t
         ref_fa
     ])
 
-    map_cmd = 'smalt map ' + extra_smalt_map_ops + ' '
+    map_cmd = 'smalt map -r 1 ' + extra_smalt_map_ops + ' '
 
     # depending on OS, -n can break smalt, so only use -n if it's > 1.
     if threads > 1:


### PR DESCRIPTION
This change just hard codes the `-r` option to 1 when you run `smalt map`, as discussed in #93. If you prefer, I can add a `--smalt_random` option to the SMALT mapping options group so users can specify the random seed when they call IVA. Can you think of a scenario where users would actually want the possibility of different results each time it runs? Would someone test to see if an assembly is stable by rerunning it 100 times?

I also switched the Dockerfile to building from the local IVA source code, because that let me test my changes in Docker. If you really prefer building from GitHub's master branch every time, I'll switch that back. I think the other changes in the Docker file are necessary to make it run after a year and a half of dependency upgrades.